### PR TITLE
Fix Dockerfile so the build can succeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN gulp
 # Build Golang binary
 FROM golang:1.11 AS build-golang
 
-WORKDIR /go/src/github.com/gophish/gophish
+WORKDIR /go/src/github.com/onvio/gophish
 COPY . .
 RUN go get -v && go build -v
 


### PR DESCRIPTION
There was no gofish executable in final image due to incorrect path to copy data from `build-golang` image.